### PR TITLE
feat(controllers): add controllerName to controller template

### DIFF
--- a/templates/controller/index.js
+++ b/templates/controller/index.js
@@ -2,6 +2,7 @@
 var controllername = '<%= controllername %>';
 
 module.exports = function(app) {
+    var fullname = app.name + '.' + controllername;
     /*jshint validthis: true */
 
     var deps = [];
@@ -9,6 +10,8 @@ module.exports = function(app) {
     function controller() {
         var vm = this;
         vm.message = 'Hello World';
+        vm.controllerName = fullname;
+
         var activate = function() {
 
         };
@@ -16,5 +19,5 @@ module.exports = function(app) {
     }
 
     controller.$inject = deps;
-    app.controller(app.name + '.' + controllername, controller);
+    app.controller(fullname, controller);
 };


### PR DESCRIPTION
Added a controllerName property to controller scope (`vm`). 

This is useful for debugging purposes whilst injecting.

I would have:
1. replaced `vm.message` but was unsure whether or not that would break any tests.
2. added a related test but could not find any existing tests that check generated output.